### PR TITLE
Add moderation endpoints

### DIFF
--- a/rickchurch/auth.py
+++ b/rickchurch/auth.py
@@ -75,7 +75,7 @@ async def authorized(authorization: Optional[str], asyncpg_conn: asyncpg.Connect
     user_id = token_data["id"]
     token_salt = token_data["salt"]
     user_state = await asyncpg_conn.fetchrow(
-        "SELECT is_banned, is_mod, key_salt, FROM users WHERE user_id = $1;", int(user_id)
+        "SELECT is_banned, is_mod, key_salt FROM users WHERE user_id = $1;", int(user_id)
     )
     if user_state is None or user_state["key_salt"] != token_salt:
         return AuthResult(AuthState.INVALID_TOKEN, None)

--- a/rickchurch/church.py
+++ b/rickchurch/church.py
@@ -149,7 +149,7 @@ async def index(request: fastapi.Request) -> fastapi.Response:
 # endregion
 # region: Member API Endpoints
 
-@app.get("/get_projects", tags=["Member endpoint"], response_model=List[Project])
+@app.get("/projects", tags=["Member endpoint"], response_model=List[Project])
 async def get_projects(request: fastapi.Request) -> List[ProjectDetails]:
     """Obtain all active project data."""
     request.state.auth.raise_if_failed()
@@ -166,7 +166,7 @@ async def mod_check(request: fastapi.Request) -> Message:
     return Message(message="You are a moderator!")
 
 
-@app.post("/set_mod", tags=["Moderation endpoint"], response_model=Message)
+@app.post("/mods/set_mod", tags=["Moderation endpoint"], response_model=Message)
 async def set_mod(request: fastapi.Request, user: User) -> Message:
     """Make another user a moderator"""
     request.state.auth.raise_unless_mod()
@@ -185,7 +185,7 @@ async def set_mod(request: fastapi.Request, user: User) -> Message:
     return Message(message=f"Successfully set user with user_id {user.user_id} to mod")
 
 
-@app.post("/mod_ban", tags=["Moderation endpoint"], response_model=Message)
+@app.post("/mods/ban", tags=["Moderation endpoint"], response_model=Message)
 async def ban_user(request: fastapi.Request, user: User) -> Message:
     """Ban users from using the API."""
     request.state.auth.raise_unless_mod()
@@ -201,7 +201,7 @@ async def ban_user(request: fastapi.Request, user: User) -> Message:
     return Message(message=f"Successfully banned user_id {user.user_id}")
 
 
-@app.post("/mod_add_project", tags=["Moderation endpoint"], response_model=Message)
+@app.post("/mods/project", tags=["Moderation endpoint"], response_model=Message)
 async def add_project(request: fastapi.Request, project: ProjectDetails) -> Message:
     """Add a new project"""
     request.state.auth.raise_unless_mod()
@@ -221,7 +221,7 @@ async def add_project(request: fastapi.Request, project: ProjectDetails) -> Mess
     return Message(message=f"Project {project.name} was added successfully.")
 
 
-@app.delete("/mod_remove_project", tags=["Moderation endpoint"], response_model=Message)
+@app.delete("/mods/project", tags=["Moderation endpoint"], response_model=Message)
 async def remove_project(request: fastapi.Request, project: Project) -> Message:
     """Add a new project"""
     request.state.auth.raise_unless_mod()

--- a/rickchurch/church.py
+++ b/rickchurch/church.py
@@ -164,7 +164,7 @@ async def get_projects(request: fastapi.Request) -> List[ProjectDetails]:
 # endregion
 # region: Moderation API endpoints
 
-@app.get("/mod", tags=["Moderation Endpoint"], response_model=Message)
+@app.get("/mods/check", tags=["Moderation Endpoint"], response_model=Message)
 async def mod_check(request: fastapi.Request) -> Message:
     """Check if the authenticated user is a mod."""
     request.state.auth.raise_unless_mod()

--- a/rickchurch/church.py
+++ b/rickchurch/church.py
@@ -220,4 +220,20 @@ async def add_project(request: fastapi.Request, project: ProjectDetails) -> Mess
     )
     return Message(message=f"Project {project.name} was added successfully.")
 
+
+@app.delete("/mod_remove_project", tags=["Moderation endpoint"], response_model=Message)
+async def remove_project(request: fastapi.Request, project: Project) -> Message:
+    """Add a new project"""
+    request.state.auth.raise_unless_mod()
+
+    db_conn = request.state.db_conn
+    db_project = await db_conn.fetchrow("SELECT * FROM projects WHERE project_name=$1", project.name)
+
+    if db_project is None:
+        # Raise HTTP 422 (Unprocessable Entity) if this project doesn't exists
+        raise fastapi.HTTPException(status_code=422, detail=f"Database project {project.name} doesn't exists.")
+
+    await db_conn.execute("DELETE FROM projects WHERE project_name=$1", project.name)
+    return Message(message=f"Project {project.name} was added successfully.")
+
 # endregion

--- a/rickchurch/church.py
+++ b/rickchurch/church.py
@@ -139,7 +139,15 @@ async def show_token(request: fastapi.Request, token: str = fastapi.Cookie(None)
 
 
 # endregion
-# region: Member Endpoints
+# region: General Endpoints
+
+@app.get("/", include_in_schema=False, tags=["Member endpoint"])
+async def index(request: fastapi.Request) -> fastapi.Response:
+    return templates.TemplateResponse("index.html", {"request": request})
+
+
+# endregion
+# region: Member API Endpoints
 
 @app.get("/get_projects", tags=["Member endpoint"], response_model=List[Project])
 async def get_projects(request: fastapi.Request) -> List[Project]:
@@ -147,8 +155,6 @@ async def get_projects(request: fastapi.Request) -> List[Project]:
     return await fetch_projects(request.state.db_conn)
 
 
-@app.get("/", include_in_schema=False, tags=["Member endpoint"])
-async def index(request: fastapi.Request) -> fastapi.Response:
-    return templates.TemplateResponse("index.html", {"request": request})
-
+# endregion
+# region: Moderation API endpoints
 # endregion

--- a/rickchurch/church.py
+++ b/rickchurch/church.py
@@ -11,7 +11,7 @@ from fastapi.templating import Jinja2Templates
 from rickchurch import constants
 from rickchurch.auth import add_user, authorized
 from rickchurch.log import setup_logging
-from rickchurch.models import Message, Project, User
+from rickchurch.models import Message, Project, ProjectDetails, User
 from rickchurch.utils import fetch_projects, get_oauth_user
 
 logger = logging.getLogger("rickchurch")
@@ -150,7 +150,7 @@ async def index(request: fastapi.Request) -> fastapi.Response:
 # region: Member API Endpoints
 
 @app.get("/get_projects", tags=["Member endpoint"], response_model=List[Project])
-async def get_projects(request: fastapi.Request) -> List[Project]:
+async def get_projects(request: fastapi.Request) -> List[ProjectDetails]:
     """Obtain all active project data."""
     request.state.auth.raise_if_failed()
     return await fetch_projects(request.state.db_conn)
@@ -202,7 +202,7 @@ async def ban_user(request: fastapi.Request, user: User) -> Message:
 
 
 @app.post("/mod_add_project", tags=["Moderation endpoint"], response_model=Message)
-async def add_project(request: fastapi.Request, project: Project) -> Message:
+async def add_project(request: fastapi.Request, project: ProjectDetails) -> Message:
     """Add a new project"""
     request.state.auth.raise_unless_mod()
 

--- a/rickchurch/church.py
+++ b/rickchurch/church.py
@@ -159,6 +159,13 @@ async def get_projects(request: fastapi.Request) -> List[Project]:
 # endregion
 # region: Moderation API endpoints
 
+@app.get("/mod", tags=["Moderation Endpoint"], response_model=Message)
+async def mod_check(request: fastapi.Request) -> Message:
+    """Check if the authenticated user is a mod."""
+    request.state.auth.raise_unless_mod()
+    return Message(message="You are a moderator!")
+
+
 @app.post("/set_mod", tags=["Moderation endpoint"], response_model=Message)
 async def set_mod(request: fastapi.Request, user: User) -> Message:
     request.state.auth.raise_unless_mod()

--- a/rickchurch/church.py
+++ b/rickchurch/church.py
@@ -185,8 +185,8 @@ async def set_mod(request: fastapi.Request, user: User) -> Message:
     return Message(message=f"Successfully set user with user_id {user.user_id} to mod")
 
 
-@app.post("/mod_ban", tags=["Moderation Endpoint"], response_model=Message)
-async def ban_users(request: fastapi.Request, user: User) -> Message:
+@app.post("/mod_ban", tags=["Moderation endpoint"], response_model=Message)
+async def ban_user(request: fastapi.Request, user: User) -> Message:
     """Ban users from using the API."""
     request.state.auth.raise_unless_mod()
 

--- a/rickchurch/church.py
+++ b/rickchurch/church.py
@@ -141,7 +141,7 @@ async def show_token(request: fastapi.Request, token: str = fastapi.Cookie(None)
 # endregion
 # region: General Endpoints
 
-@app.get("/", include_in_schema=False, tags=["Member endpoint"])
+@app.get("/", include_in_schema=False, tags=["General endpoint"])
 async def index(request: fastapi.Request) -> fastapi.Response:
     return templates.TemplateResponse("index.html", {"request": request})
 

--- a/rickchurch/models.py
+++ b/rickchurch/models.py
@@ -26,13 +26,18 @@ class Task(pydantic.BaseModel):
             )
 
 
-class Project(pydantic.BaseModel):
+class ProjectDetails(pydantic.BaseModel):
     """A project used by the API."""
     name: str
     x: int
     y: int
     priority: int
     image: str  # base64 encoded image string
+
+
+class Project(pydantic.BaseModel):
+    """Identifiable project. Name is all we need to find any project."""
+    name: str
 
 
 class User(pydantic.BaseModel):

--- a/rickchurch/models.py
+++ b/rickchurch/models.py
@@ -33,3 +33,22 @@ class Project(pydantic.BaseModel):
     y: int
     priority: int
     image: str  # base64 encoded image string
+
+
+class User(pydantic.BaseModel):
+    """A user as used by the API."""
+
+    user_id: int
+
+    @pydantic.validator("user_id")
+    def user_id_must_be_snowflake(cls, user_id: int) -> int:  # noqa: N805 - method argument should be self
+        """Ensure the user_id is a valid discord snowflake."""
+        if user_id.bit_length() <= 63:
+            return user_id
+        else:
+            raise ValueError("user_id must fit within a 64 bit int.")
+
+
+class Message(pydantic.BaseModel):
+    """An API response message."""
+    message: str

--- a/rickchurch/utils.py
+++ b/rickchurch/utils.py
@@ -5,19 +5,19 @@ import asyncpg
 import httpx
 
 from rickchurch import constants
-from rickchurch.models import Project
+from rickchurch.models import ProjectDetails
 
 logger = logging.getLogger("rickchurch")
 
 
-async def fetch_projects(db_conn: asyncpg.Connection) -> List[Project]:
+async def fetch_projects(db_conn: asyncpg.Connection) -> List[ProjectDetails]:
     """Obtain list of active projects in the database"""
     async with db_conn.transaction():
         db_projects = await db_conn.fetchrow("SELECT * FROM projects")
 
     projects = []
     for db_project in db_projects:
-        project = Project(
+        project = ProjectDetails(
             name=db_project["project_name"],
             x=db_project["position_x"],
             y=db_project["position_y"],


### PR DESCRIPTION
Add endpoints only available to moderators. These endpoints are:
 - [x] GET `/mods/check`: Test if user is a mod
 - [x] POST `/mods/promote`: Set an existing user as a mod
 - [x] POST `/mods/demote`: Set an existing mod as regular user
 - [x] POST `/mods/ban`: Ban an existing user from the API
 - [x]  POST `/mods/project`: Add a new project to the API
 - [x] DELETE `/mods/project`: Remove a project from the API
 - [x] PUT `/mods/project`: Update a project from the API (re-send entire project)