### PR TITLE
Add task managing endpoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM tiangolo/uvicorn-gunicorn-fastapi:python3.8
 # Set pip to have no saved cache
 ENV PIP_NO_CACHE_DIR=false \
     MODULE_NAME="rickchurch" \
-    MAX_WORKERS=10
+    MAX_WORKERS=1
 
 # Install poetry
 RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | POETRY_HOME=/opt/poetry python && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,4 +29,5 @@ services:
     ports:
       - "127.0.0.1:8000:80"
     environment:
+      MAX_WORKERS: 1
       DATABASE_URL: postgres://rickchurch:rickchurch@postgres:5432/rickchurch

--- a/poetry.lock
+++ b/poetry.lock
@@ -759,7 +759,7 @@ email = ["email-validator (>=1.0.3)"]
 
 [[package]]
 name = "pydispix"
-version = "1.1.0"
+version = "1.2.2"
 description = "API wrapper for python-discord's pixels."
 category = "main"
 optional = false
@@ -776,7 +776,7 @@ requests = "~=2.25.1"
 type = "git"
 url = "https://github.com/ItsDrike/pydispix"
 reference = "async"
-resolved_reference = "0a15e765456a1fff2e2530d87e393aa686022ffe"
+resolved_reference = "2ffd42bc2cfa928256c69f88fee1db94f9d1671a"
 
 [[package]]
 name = "pyflakes"
@@ -1094,7 +1094,7 @@ python-versions = ">=3.6.1"
 [metadata]
 lock-version = "1.1"
 python-versions = "3.8.*"
-content-hash = "ed7e719440a3fedd3e8956fe3342fd8195dfb173914d18ad8726613e0f6e49b3"
+content-hash = "98ef9fa3b223edc89304782d1992d7e38dc27aca9a44d8a9ee23630fd71c3cb9"
 
 [metadata.files]
 aiofiles = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -759,7 +759,7 @@ email = ["email-validator (>=1.0.3)"]
 
 [[package]]
 name = "pydispix"
-version = "1.2.2"
+version = "1.2.3"
 description = "API wrapper for python-discord's pixels."
 category = "main"
 optional = false
@@ -768,6 +768,7 @@ develop = false
 
 [package.dependencies]
 colorama = "~=0.4.4"
+httpx = "^0.18.1"
 matplotlib = "~=3.4.2"
 pillow = "~=8.2.0"
 requests = "~=2.25.1"
@@ -776,7 +777,7 @@ requests = "~=2.25.1"
 type = "git"
 url = "https://github.com/ItsDrike/pydispix"
 reference = "async"
-resolved_reference = "2ffd42bc2cfa928256c69f88fee1db94f9d1671a"
+resolved_reference = "c615c01743c649d9aecefcaa0a97d1327d6f8550"
 
 [[package]]
 name = "pyflakes"
@@ -834,21 +835,20 @@ cli = ["click (>=5.0)"]
 
 [[package]]
 name = "python-jose"
-version = "3.2.0"
+version = "3.3.0"
 description = "JOSE implementation in Python"
 category = "main"
 optional = false
 python-versions = "*"
 
 [package.dependencies]
-cryptography = {version = "*", optional = true, markers = "extra == \"cryptography\""}
-ecdsa = "<0.15"
+cryptography = {version = ">=3.4.0", optional = true, markers = "extra == \"cryptography\""}
+ecdsa = "!=0.15"
 pyasn1 = "*"
 rsa = "*"
-six = "<2.0"
 
 [package.extras]
-cryptography = ["cryptography"]
+cryptography = ["cryptography (>=3.4.0)"]
 pycrypto = ["pycrypto (>=2.6.0,<2.7.0)", "pyasn1"]
 pycryptodome = ["pycryptodome (>=3.3.1,<4.0.0)", "pyasn1"]
 
@@ -1682,8 +1682,8 @@ python-dotenv = [
     {file = "python_dotenv-0.17.1-py2.py3-none-any.whl", hash = "sha256:00aa34e92d992e9f8383730816359647f358f4a3be1ba45e5a5cefd27ee91544"},
 ]
 python-jose = [
-    {file = "python-jose-3.2.0.tar.gz", hash = "sha256:4e4192402e100b5fb09de5a8ea6bcc39c36ad4526341c123d401e2561720335b"},
-    {file = "python_jose-3.2.0-py2.py3-none-any.whl", hash = "sha256:67d7dfff599df676b04a996520d9be90d6cdb7e6dd10b4c7cacc0c3e2e92f2be"},
+    {file = "python-jose-3.3.0.tar.gz", hash = "sha256:55779b5e6ad599c6336191246e95eb2293a9ddebd555f796a65f838f07e5d78a"},
+    {file = "python_jose-3.3.0-py2.py3-none-any.whl", hash = "sha256:9b1376b023f8b298536eedd47ae1089bcdb848f1535ab30555cd92002d78923a"},
 ]
 python-multipart = [
     {file = "python-multipart-0.0.5.tar.gz", hash = "sha256:f7bb5f611fc600d15fa47b3974c8aa16e93724513b49b5f95c81e6624c83fa43"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,12 @@ license = "AGPL"
 [tool.poetry.dependencies]
 python = "3.8.*"
 fastapi = {extras = ["all"], version = "^0.65.1"}
-pydispix = {git = "https://github.com/ItsDrike/pydispix", rev = "async"}
 python-decouple = "^3.4"
 python-jose = {extras = ["cryptography"], version = "^3.2.0"}
 asyncpg = "^0.23.0"
 httpx = "^0.18.1"
+Pillow = "^8.2.0"
+pydispix = {git = "https://github.com/ItsDrike/pydispix", rev = "async"}
 
 [tool.poetry.dev-dependencies]
 autopep8 = "~=1.5.7"

--- a/rickchurch/church.py
+++ b/rickchurch/church.py
@@ -186,7 +186,7 @@ async def roll(request: fastapi.Request) -> fastapi.Response:
 # region: Member API Endpoints
 
 
-@app.get("/projects", tags=["Member endpoint"], response_model=List[Project])
+@app.get("/projects", tags=["Member endpoint"], response_model=List[ProjectDetails])
 async def get_projects(request: fastapi.Request) -> List[ProjectDetails]:
     """Obtain all active project data."""
     request.state.auth.raise_if_failed()

--- a/rickchurch/church.py
+++ b/rickchurch/church.py
@@ -303,7 +303,7 @@ async def remove_project(request: fastapi.Request, project: Project) -> Message:
         raise fastapi.HTTPException(status_code=404, detail=f"Database project {project.name} doesn't exist.")
 
     await db_conn.execute("DELETE FROM projects WHERE project_name=$1", project.name)
-    return Message(message=f"Project {project.name} was added successfully.")
+    return Message(message=f"Project {project.name} was removed successfully.")
 
 
 @app.put("/mods/project", tags=["Moderation endpoint"], response_model=Message)

--- a/rickchurch/constants.py
+++ b/rickchurch/constants.py
@@ -17,7 +17,6 @@ client_secret: str = config("CLIENT_SECRET")
 oauth_redirect_url: str = config("OAUTH_REDIRECT_URL")
 
 jwt_secret: str = config("JWT_SECRET")
-pixels_api_token: str = config("PIXELS_API_TOKEN")
 
 # How long should a task stay assigned to the user who requested it (seconds)
 task_pending_delay: float = config("TASK_PENDING_DELAY", default=5.0, cast=float)
@@ -35,7 +34,7 @@ DB_POOL = asyncpg.create_pool(
     max_size=max_pool_size
 )
 
-CLIENT = pydispix.Client(pixels_api_token)
+CLIENT = pydispix.Client(config("PIXELS_API_TOKEN"))
 
 with open("rickchurch/resources/mods.txt") as f:
     mods = [int(entry) for entry in f.read().split()]

--- a/rickchurch/constants.py
+++ b/rickchurch/constants.py
@@ -1,5 +1,6 @@
 # type: ignore - config function gives str|bool|Unknown, we specify it with type-hint
 import asyncpg
+import pydispix
 from decouple import config
 
 
@@ -31,6 +32,8 @@ DB_POOL = asyncpg.create_pool(
     min_size=min_pool_size,
     max_size=max_pool_size
 )
+
+CLIENT = pydispix.Client(pixels_api_token)
 
 with open("rickchurch/resources/mods.txt") as f:
     mods = [int(entry) for entry in f.read().split()]

--- a/rickchurch/constants.py
+++ b/rickchurch/constants.py
@@ -19,6 +19,7 @@ jwt_secret: str = config("JWT_SECRET")
 pixels_api_token: str = config("PIXELS_API_TOKEN")
 
 task_pending_delay: int = config("TASK_PENDING_DELAY", default=5, cast=int)
+task_refresh_time: int = config("TASK_REFRESH_TIME", default=5, cast=int)
 
 # PostgreSQL Database
 database_url: str = config("DATABASE_URL")

--- a/rickchurch/constants.py
+++ b/rickchurch/constants.py
@@ -34,7 +34,7 @@ max_pool_size: int = config("MAX_POOL_SIZE", cast=int, default=5)
 # Awaited in application startup
 DB_POOL = asyncpg.create_pool(database_url, min_size=min_pool_size, max_size=max_pool_size)
 
-CLIENT = pydispix.Client(config("PIXELS_API_TOKEN"))
+PYDISPIX_CLIENT = pydispix.Client(config("PIXELS_API_TOKEN"))
 
 with open("rickchurch/resources/mods.txt") as f:
     mods = [int(entry) for entry in f.read().split()]

--- a/rickchurch/constants.py
+++ b/rickchurch/constants.py
@@ -19,8 +19,10 @@ oauth_redirect_url: str = config("OAUTH_REDIRECT_URL")
 jwt_secret: str = config("JWT_SECRET")
 pixels_api_token: str = config("PIXELS_API_TOKEN")
 
-task_pending_delay: int = config("TASK_PENDING_DELAY", default=5, cast=int)
-task_refresh_time: int = config("TASK_REFRESH_TIME", default=5, cast=int)
+# How long should a task stay assigned to the user who requested it (seconds)
+task_pending_delay: float = config("TASK_PENDING_DELAY", default=5.0, cast=float)
+# How often should we refresh all tasks from database and refetch the canvas (seconds)
+task_refresh_time: float = config("TASK_REFRESH_TIME", default=2.0, cast=float)
 
 # PostgreSQL Database
 database_url: str = config("DATABASE_URL")

--- a/rickchurch/constants.py
+++ b/rickchurch/constants.py
@@ -18,6 +18,8 @@ oauth_redirect_url: str = config("OAUTH_REDIRECT_URL")
 jwt_secret: str = config("JWT_SECRET")
 pixels_api_token: str = config("PIXELS_API_TOKEN")
 
+task_pending_delay: int = config("TASK_PENDING_DELAY", default=5, cast=int)
+
 # PostgreSQL Database
 database_url: str = config("DATABASE_URL")
 min_pool_size: int = config("MIN_POOL_SIZE", cast=int, default=2)

--- a/rickchurch/models.py
+++ b/rickchurch/models.py
@@ -25,6 +25,10 @@ class Task(pydantic.BaseModel):
                 "for example FF00ff for purple."
             )
 
+    def __hash__(self):
+        # Make sure same tasks have the same hash, for easy O(1) lookups
+        return hash((self.x, self.y, self.rgb))
+
 
 class ProjectDetails(pydantic.BaseModel):
     """A project used by the API."""

--- a/rickchurch/models.py
+++ b/rickchurch/models.py
@@ -16,6 +16,7 @@ class Task(pydantic.BaseModel):
     x: int
     y: int
     rgb: str
+    project_name: str
 
     # Validators for x and y aren't added, because we don't know canvas dimensions
     # and we can't make async request for them here, so we only validate rgb
@@ -33,7 +34,7 @@ class Task(pydantic.BaseModel):
 
     def __hash__(self):
         # Make sure same tasks have the same hash, for easy O(1) lookups
-        return hash((self.x, self.y, self.rgb))
+        return hash((self.x, self.y, self.rgb, self.project_name))
 
 
 class ProjectDetails(pydantic.BaseModel):

--- a/rickchurch/models.py
+++ b/rickchurch/models.py
@@ -3,9 +3,9 @@ import binascii
 import re
 from io import BytesIO
 
-import pydantic
 import PIL
 import PIL.Image
+import pydantic
 
 _RGB_RE = re.compile(r"[0-9a-fA-F]{6}")
 

--- a/rickchurch/tasks.py
+++ b/rickchurch/tasks.py
@@ -103,11 +103,11 @@ async def assign_free_task(user_id: int) -> Task:
     task = random.choice(free_tasks)
     free_tasks.remove(task)
     tasks[user_id] = task
-    await postpone(
+    asyncio.create_task(postpone(
         constants.task_pending_delay,
         to_coro(unassign_task, user_id),
         predicate=lambda: user_id in tasks
-    )
+    ))
     return task
 
 
@@ -116,7 +116,6 @@ def unassign_task(user_id: int) -> None:
     global tasks
     global free_tasks
 
-    logger.info("Task unassigned")
     task = tasks[user_id]
     del tasks[user_id]
     free_tasks.append(task)

--- a/rickchurch/tasks.py
+++ b/rickchurch/tasks.py
@@ -68,19 +68,19 @@ async def get_fastest_pixel(x: int, y: int, submit_time: float) -> pydispix.Pixe
         # we can just wait it out if it's not too long
 
         # Check if expected time for use get_pixel endpoint wouldn't be lower
-        url = constants.CLIENT.resolve_endpoint("/get_pixel")
+        url = constants.PYDISPIX_CLIENT.resolve_endpoint("/get_pixel")
         # TODO: Waiting on pydispix update, make_raw_request needs to use httpx/async
-        constants.CLIENT.make_raw_request(
+        constants.PYDISPIX_CLIENT.make_raw_request(
             "HEAD", url,
-            headers=constants.CLIENT.headers,
+            headers=constants.PYDISPIX_CLIENT.headers,
             update_rate_limits=True
         )
-        wait_time = constants.CLIENT.rate_limiter.rate_limits[url].get_wait_time()
+        wait_time = constants.PYDISPIX_CLIENT.rate_limiter.rate_limits[url].get_wait_time()
         expected_get_pixel_time = wait_time + time.time()
 
         if expected_update_time > expected_get_pixel_time:
             # Using get_pixel will be faster than waiting for canvas update
-            return await constants.CLIENT.get_pixel(x, y)
+            return await constants.PYDISPIX_CLIENT.get_pixel(x, y)
 
     # Waiting for get_pixel would take longer, wait out the canvas update
     wait_time = expected_update_time - time.time()
@@ -151,7 +151,7 @@ async def update_tasks() -> None:
     global update_time
     global canvas
 
-    canvas = await constants.CLIENT.get_canvas()
+    canvas = await constants.PYDISPIX_CLIENT.get_canvas()
 
     local_tasks = []
     for project in projects:

--- a/rickchurch/tasks.py
+++ b/rickchurch/tasks.py
@@ -176,7 +176,22 @@ async def update_tasks() -> None:
 
             local_tasks.append(Task(x=x, y=y, rgb=pydispix.parse_color(color), project_name=project.name))
 
-    active_tasks = set(free_tasks).union(set(tasks.values()))
+    # Set some variables for fast lookups
+    local_tasks_set = set(local_tasks)
+    free_tasks_set = set(free_tasks)
+    tasks_set = set(tasks.values())
+    rev_tasks = {value: key for key, value in tasks.items()}
+    active_tasks = free_tasks_set.union(tasks_set)
+
+    # Remove tasks that aren't tracked anymore (from removed projects)
+    for task in active_tasks:
+        if task not in local_tasks_set:
+            if task in free_tasks_set:
+                free_tasks.remove(task)
+            elif task in rev_tasks:
+                key = rev_tasks[task]
+                del tasks[key]
+
     for task in local_tasks:
         if task in active_tasks:
             continue

--- a/rickchurch/tasks.py
+++ b/rickchurch/tasks.py
@@ -20,8 +20,8 @@ canvas: Optional[pydispix.Canvas] = None
 update_time = float("-inf")  # Unix last update timestamp
 
 
-async def submit_task(task: Task, user_id: int):
-    """Try to submit a `task` from `user_id`"""
+async def submit_task(task: Task, user_id: int) -> None:
+    """Try to submit a `task` from `user_id`, raise 409 on fail."""
     global tasks
 
     submit_time = time.time()
@@ -89,7 +89,7 @@ async def get_fastest_pixel(x: int, y: int, submit_time: float) -> pydispix.Pixe
 
 
 async def assign_free_task(user_id: int) -> Task:
-    """Assign a free task to `user_id`"""
+    """Assign a free task to `user_id`, raise 409 on fail"""
     global tasks
     global free_tasks
 
@@ -109,7 +109,7 @@ async def assign_free_task(user_id: int) -> Task:
     return task
 
 
-def unassign_task(user_id: int):
+def unassign_task(user_id: int) -> None:
     """Unassign given `task` from `user_id` and mark it free to be claimed"""
     global tasks
     global free_tasks
@@ -119,7 +119,7 @@ def unassign_task(user_id: int):
     free_tasks.append(task)
 
 
-async def reload_loop():
+async def reload_loop() -> None:
     """
     Keep continually querying the database to update the list of projects, these updates aren't
     that common, but they happen when a new project is added/removed/edited
@@ -146,7 +146,7 @@ async def reload_loop():
         await asyncio.sleep(constants.task_refresh_time)
 
 
-async def update_tasks():
+async def update_tasks() -> None:
     global free_tasks
     global update_time
     global canvas

--- a/rickchurch/tasks.py
+++ b/rickchurch/tasks.py
@@ -66,8 +66,7 @@ async def get_fastest_pixel(x: int, y: int, submit_time: float) -> pydispix.Pixe
 
         # Check if expected time for use get_pixel endpoint wouldn't be lower
         url = constants.PYDISPIX_CLIENT.resolve_endpoint("/get_pixel")
-        # TODO: Waiting on pydispix update, make_raw_request needs to use httpx/async
-        constants.PYDISPIX_CLIENT.make_raw_request(
+        await constants.PYDISPIX_CLIENT.make_raw_request(
             "HEAD", url,
             headers=constants.PYDISPIX_CLIENT.headers,
             update_rate_limits=True

--- a/rickchurch/tasks.py
+++ b/rickchurch/tasks.py
@@ -1,0 +1,66 @@
+import random
+from functools import partial
+
+import fastapi
+
+from rickchurch import constants
+from rickchurch.models import Task
+from rickchurch.utils import postpone
+
+# Use global variables to keep track of current task list,
+# this isn't ideal, but it's the easiest solution we can use.
+tasks = {}
+free_tasks = []
+
+
+def submit_task(task: Task, user_id: int):
+    """Try to submit a `task` from `user_id`"""
+    global tasks
+
+    # This performs a linear search across the tasks, with our userbase, this shouldn't be an issue
+    # it is here to provide more detailed info to the client, since the task doesn't actually exists
+    # at all, and not just respond with reassigned.
+    if task not in tasks.values():
+        raise fastapi.HTTPException(
+            status_code=409,
+            detail="This task doesn't exist, it was likely was already completed by someone else."
+        )
+    if tasks[user_id] != task:
+        raise fastapi.HTTPException(
+            status_code=409,
+            detail="This task doesn't belong to you, "
+                   "it has likely been reassigned since you took too long to complete it."
+        )
+
+    del tasks[user_id]
+
+
+async def assign_free_task(user_id: int) -> Task:
+    """Assign a free task to `user_id`"""
+    global tasks
+    global free_tasks
+
+    if user_id in tasks:
+        raise fastapi.HTTPException(status_code=409, detail="You already have a task assigned.")
+    if len(free_tasks) == 0:
+        raise fastapi.HTTPException(status_code=409, detail="No aviable tasks.")
+
+    task = random.choice(free_tasks)
+    free_tasks.remove(task)
+    tasks[user_id] = task
+    await postpone(
+        constants.task_pending_delay,
+        partial(unassign_task, user_id),  # type: ignore - partial doesn't explicitly return coro
+        predicate=lambda: user_id in tasks
+    )
+    return task
+
+
+def unassign_task(user_id: int):
+    """Unassign given `task` from `user_id` and mark it free to be claimed"""
+    global tasks
+    global free_tasks
+
+    task = tasks[user_id]
+    del tasks[user_id]
+    free_tasks.append(task)

--- a/rickchurch/tasks.py
+++ b/rickchurch/tasks.py
@@ -28,11 +28,6 @@ async def submit_task(task: Task, user_id: int) -> None:
 
     submit_time = time.time()
 
-    if task not in tasks.values():
-        raise fastapi.HTTPException(
-            status_code=409,
-            detail="This task doesn't exist, it was likely was already completed by someone else."
-        )
     if tasks[user_id] != task:
         raise fastapi.HTTPException(
             status_code=409,

--- a/rickchurch/tasks.py
+++ b/rickchurch/tasks.py
@@ -28,7 +28,7 @@ async def submit_task(task: Task, user_id: int) -> None:
 
     submit_time = time.time()
 
-    if tasks[user_id] != task:
+    if tasks.get(user_id) != task:
         raise fastapi.HTTPException(
             status_code=409,
             detail="This task doesn't belong to you, "

--- a/rickchurch/tasks.py
+++ b/rickchurch/tasks.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import random
 import time
-from typing import Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import fastapi
 import pydispix
@@ -15,9 +15,9 @@ logger = logging.getLogger("rickchurch")
 
 # Use global variables to keep track of current task list,
 # this isn't ideal, but it's the easiest solution we can use.
-tasks = {}
-free_tasks = []
-projects = []
+tasks: Dict[int, Task] = {}
+free_tasks: List[Task] = []
+projects: List[ProjectDetails] = []
 canvas: Optional[pydispix.Canvas] = None
 update_time = float("-inf")  # Unix last update timestamp
 
@@ -174,7 +174,7 @@ async def update_tasks() -> None:
             if canvas[x, y].triple == color:
                 continue
 
-            local_tasks.append(Task(x=x, y=y, rgb=pydispix.parse_color(color)))
+            local_tasks.append(Task(x=x, y=y, rgb=pydispix.parse_color(color), project_name=project.name))
 
     active_tasks = set(free_tasks).union(set(tasks.values()))
     for task in local_tasks:

--- a/rickchurch/tasks.py
+++ b/rickchurch/tasks.py
@@ -1,25 +1,27 @@
+import asyncio
 import random
 from functools import partial
+from typing import Tuple, Union
 
+import asyncpg
 import fastapi
+import pydispix
 
 from rickchurch import constants
-from rickchurch.models import Task
-from rickchurch.utils import postpone
+from rickchurch.models import ProjectDetails, Task
+from rickchurch.utils import deserialize_image, postpone
 
 # Use global variables to keep track of current task list,
 # this isn't ideal, but it's the easiest solution we can use.
 tasks = {}
 free_tasks = []
+projects = []
 
 
 def submit_task(task: Task, user_id: int):
     """Try to submit a `task` from `user_id`"""
     global tasks
 
-    # This performs a linear search across the tasks, with our userbase, this shouldn't be an issue
-    # it is here to provide more detailed info to the client, since the task doesn't actually exists
-    # at all, and not just respond with reassigned.
     if task not in tasks.values():
         raise fastapi.HTTPException(
             status_code=409,
@@ -64,3 +66,58 @@ def unassign_task(user_id: int):
     task = tasks[user_id]
     del tasks[user_id]
     free_tasks.append(task)
+
+
+async def reload_loop(db_conn: asyncpg.Connection, reload_time: Union[int, float]):
+    """
+    Keep continually querying the database to update the list of projects, these updates aren't
+    that common, but they happen when a new project is added/removed/edited
+    """
+    global projects
+
+    while True:
+        db_projects = await db_conn.fetch("SELECT * FROM projects")
+        for db_project in db_projects:
+            project_model = ProjectDetails(
+                name=db_project["project_name"],
+                x=db_project["position_x"],
+                y=db_project["position_y"],
+                priority=db_project["priority"],
+                image=db_project["base64_image"]
+            )
+            projects.append(project_model)
+
+        asyncio.sleep(reload_time)
+
+
+async def update_tasks(client: pydispix.Client):
+    global free_tasks
+
+    canvas = await client.get_canvas()
+
+    local_tasks = []
+    for project in projects:
+        img = deserialize_image(project.image)
+
+        img_rgb = img.convert("RGB")
+        w, h = img.size
+
+        random_pixels = list(range(w * h))
+        random.shuffle(random_pixels)  # this happens in-place
+
+        for pixel_no in random_pixels:
+            x = pixel_no % w
+            y = pixel_no // w
+            color: Tuple[int, int, int] = img_rgb.getpixel((x, y))  # type: ignore - this is RGB (3x int tuple)
+
+            # Check if color is already matching
+            if canvas[x, y].triple == color:
+                continue
+
+            local_tasks.append(Task(x=x, y=y, rgb=pydispix.parse_color(color)))
+
+    active_tasks = set(free_tasks).union(set(tasks.values()))
+    for task in local_tasks:
+        if task in active_tasks:
+            continue
+        free_tasks.append(task)

--- a/rickchurch/utils.py
+++ b/rickchurch/utils.py
@@ -20,6 +20,10 @@ async def fetch_projects(db_conn: asyncpg.Connection) -> List[ProjectDetails]:
     async with db_conn.transaction():
         db_projects = await db_conn.fetchrow("SELECT * FROM projects")
 
+    # If we have a single project, it wouldn't be a list
+    if not isinstance(db_projects, list):
+        db_projects = [db_projects]
+
     projects = []
     for db_project in db_projects:
         project = ProjectDetails(

--- a/rickchurch/utils.py
+++ b/rickchurch/utils.py
@@ -1,8 +1,11 @@
 import asyncio
+import base64
 import inspect
 import logging
+from io import BytesIO
 from typing import Callable, Coroutine, List, Union
 
+import PIL.Image
 import asyncpg
 import httpx
 
@@ -60,6 +63,18 @@ async def get_oauth_user(code: str) -> dict:
         user = response.json()
 
     return user
+
+
+def deserialize_image(base64_string: str) -> PIL.Image.Image:
+    """Convert serialized base64 image string to an actual image"""
+    return PIL.Image.open(BytesIO(base64.b64decode(base64_string)))
+
+
+def serialize_image(image: PIL.Image.Image) -> str:
+    """Convert an actual image into deserialized base64 string"""
+    f = BytesIO()
+    image.save(f, format="PNG")
+    return base64.b64encode(f.getvalue()).decode()
 
 
 async def postpone(seconds: Union[int, float], coro: Coroutine, predicate: Callable):

--- a/rickchurch/utils.py
+++ b/rickchurch/utils.py
@@ -83,7 +83,7 @@ def serialize_image(image: PIL.Image.Image) -> str:
 async def postpone(seconds: Union[int, float], coro: Coroutine, predicate: Callable):
     try:
         await asyncio.sleep(seconds)
-        if predicate is True:
+        if predicate() is True:
             # Prevent `coro` from cancelling itself by shielding it
             await asyncio.shield(coro)
     finally:
@@ -91,3 +91,7 @@ async def postpone(seconds: Union[int, float], coro: Coroutine, predicate: Calla
         # But only do so if it wasn't awaited yet, since the coro can also cancel itself
         if inspect.getcoroutinestate(coro) == "CORO_CREATED":
             coro.close()
+
+
+async def to_coro(sync_func: Callable, *args, **kwargs):
+    return sync_func(*args, **kwargs)

--- a/rickchurch/utils.py
+++ b/rickchurch/utils.py
@@ -18,11 +18,7 @@ logger = logging.getLogger("rickchurch")
 async def fetch_projects(db_conn: asyncpg.Connection) -> List[ProjectDetails]:
     """Obtain list of active projects in the database"""
     async with db_conn.transaction():
-        db_projects = await db_conn.fetchrow("SELECT * FROM projects")
-
-    # If we have a single project, it wouldn't be a list
-    if not isinstance(db_projects, list):
-        db_projects = [db_projects]
+        db_projects = await db_conn.fetch("SELECT * FROM projects")
 
     projects = []
     for db_project in db_projects:


### PR DESCRIPTION
## Details
Add `task` endpoint with `GET` and `POST` that handles distributing tasks to members.

My implementation seems to be working, but I haven't done that much testing yet. Certainly not with multiple clients, and not even proper task submission that went though, that's why this PR is still marked as a draft, though the implementation should probably be more or less ready after the testing.

Note: The current implementation assigns tasks completely randomly, the `priority` attribute is completely ignored. This should be fixed in the future, either later in this PR, or in another PR. We should also be using `weight` instead of hard priorities, for a more granular control over the task distribution

## Testing

Before this PR gets merged, it should be sufficiently tested. I've already set up a branch in `pydispix` that should support this new version of the API and can fulfill the tasks from it. 

In order to use it, execute: `pip install git+https://github.com/ItsDrike/pydispix@rick-church-update` after which you can run the original script, it will use the new API and it will assume that the church is hosted at `localhost:8000`, alternatively use `base_church_url` kwarg for `RickChurchClient` when initializing to set a different URL.

Testing of this PR is very important, since task distribution is perhaps the most important piece of the actual API logic and we need to make sure that it is working as it should be. Ideally, we should set up a beta test version with beta-testers running that version instead of the main API and test out whether the task distribution works properly with multiple clients and with multiple projects.

## Single worker requirement
This requires us to only run single worker for the API. Otherwise the `startup` runs multiple times in multiple processes, yet we only have a single pixels API token to be used for obtaining the canvas. Running this multiple times would mean that we would be hitting needless rate-limits.

The only alternative to single worker would be process wide locks, ideally with a database like redis, that is fast enough since it lives in memory. Or building a micro-service that would relay the information to our API. I didn't do any of these because it seems like over-engineering things and adding extra complexity for no real reason. This would only become important if we had to scale and run multiple instances of the church to load balance the requests, which is very unlikely considering the amount of users we currently have.