### PR TITLE
Remove url_for, use absoulte urls

### DIFF
--- a/rickchurch/templates/api_token.html
+++ b/rickchurch/templates/api_token.html
@@ -6,6 +6,6 @@
     <h1>Success</h1>
     <p>You've been added to the church. Here is your API key</p>
     <pre>{{ token }}</pre>
-    <img src="{{ url_for('static', path='cookie-monster.gif') }}" alt="cookie monster eating cookies"></img>
+    <img src="/static/cookie-monster.gif" alt="cookie monster eating cookies"></img>
   </div>
 {% endblock %}

--- a/rickchurch/templates/base.html
+++ b/rickchurch/templates/base.html
@@ -5,7 +5,7 @@
   <title>Church of Rick • {% block subtitle %}{% endblock %}</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="static/styles.css">
+  <link rel="stylesheet" href="/static/styles.css">
   {% block head %}{% endblock %}
 </head>
 

--- a/rickchurch/templates/base.html
+++ b/rickchurch/templates/base.html
@@ -5,7 +5,7 @@
   <title>Church of Rick • {% block subtitle %}{% endblock %}</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="{{ url_for('static', path='/styles.css') }}">
+  <link rel="stylesheet" href="static/styles.css">
   {% block head %}{% endblock %}
 </head>
 

--- a/rickchurch/templates/cookie_disabled.html
+++ b/rickchurch/templates/cookie_disabled.html
@@ -9,6 +9,6 @@
         <p>You can follow <a href="https://www.whatismybrowser.com/guides/how-to-enable-cookies/" target="_blank">this guide</a> to enable them.</p>
         <p>After you've enabled cookies navigate back to <a href="/authorize">/authorize</a></p>
 
-        <img src="{{ url_for('static', path='cookie-monster-sad.jpg') }}" alt="sad cookie monster"></img>
+        <img src="cookie-monster-sad.jpg" alt="sad cookie monster"></img>
     </div>
 {% endblock %}

--- a/rickchurch/templates/docs.html
+++ b/rickchurch/templates/docs.html
@@ -13,7 +13,7 @@
         render-style="read"
         >
         <div slot="nav-logo">
-            <img src="{{ url_for('static', path='/rick.png') }}" alt="rick" style="display: block; margin: 0 auto;"></img>
+            <img src="/static/rick.png" alt="rick" style="display: block; margin: 0 auto;"></img>
             <p style="text-align: center;"><b>Church of Rick™</b></p>
         </div>
     </rapi-doc>

--- a/rickchurch/templates/index.html
+++ b/rickchurch/templates/index.html
@@ -4,7 +4,7 @@
 {% block body %}
     <div class="home">
         <h1>The Church of Rick™</h1>
-        <img src="{{ url_for('static', path='/rick.png') }}" alt="rick"></img>
+        <img src="/static/rick.png" alt="rick"></img>
         <p>We're an advanced organization of trolls drawing rick all over the python discord pixels event</p>
 
         <p><a class="btn" href="/authorize">Join the movement</a></p>


### PR DESCRIPTION
`url_for` was not working correctly behind nginx
![image](https://user-images.githubusercontent.com/26258618/121288779-e283ff00-c8b1-11eb-9dec-3c04ab50d021.png)
I tried to fix it without removing it but I could not find any good docs, startlette and fastapi did not give details.

If you can fix it without removing `url_for` then fine, but I think its just added complexity for zero utility. If you wanted to host it on some weird path like `foo.com/rickchurch` as root, you can just use relative URLs.

I used absolute URLs in this PR though since I don't think we'll be mounting on `/rickchurch` or anything anytime soon, and when we do its an easy change. while using relative URLs might cause bugs when changing paths without updating templates.